### PR TITLE
Fix libraries and includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,4 +68,4 @@ cuda_add_executable(cuMain
            )
 
 
-TARGET_LINK_LIBRARIES(cuMain custinger  /usr/local/cuda/lib64/libcudart.so)
+TARGET_LINK_LIBRARIES(cuMain custinger ${CUDA_LIBRARIES})

--- a/src/cuStingerInsertions.cpp
+++ b/src/cuStingerInsertions.cpp
@@ -4,6 +4,8 @@
 
 #include <unordered_map>
 #include <algorithm>
+#include <cmath>
+using std::ceil;
 
 #include "utils.hpp"
 #include "update.hpp"

--- a/src/memoryManager.cpp
+++ b/src/memoryManager.cpp
@@ -2,7 +2,8 @@
 #include <numeric>
 #include <stdlib.h>
 #include <inttypes.h>
-
+#include <cmath>
+using std::ceil;
 
 #include "memoryManager.hpp"
 


### PR DESCRIPTION
Includes two minor fixes I made to get the project to build:
- `ceil` was not being included anywhere. Other compilers might just allow this to be declared implicitly but mine (gcc 5.4.0) complained. 
- Use CMake provided variable to find libcudart instead of assuming hard coded path.